### PR TITLE
Throw error only in case of singular mass matrix

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -2,8 +2,8 @@ function DiffEqBase.__solve(prob::DiffEqBase.AbstractSteadyStateProblem,
                             alg::SteadyStateDiffEqAlgorithm,args...;
                             abstol=1e-8,kwargs...)
 
-  if prob.f.mass_matrix != I
-    error("This solver is not able to use mass matrices.")
+  if det(prob.f.mass_matrix) == 0
+    error("This solver is not able to use singular mass matrices.")
   end
 
   if typeof(prob.u0) <: Number

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -8,7 +8,7 @@ function DiffEqBase.__solve(prob::DiffEqBase.AbstractSteadyStateProblem,
   M_rest = M[mask,mask] # Non-algebraic part
   
   if rank(M_rest) < minimum(size(M_rest)) 
-    error("This solver is not able to use mass matrices, wich non-algebraic part is singular")
+    error("This solver is not able to use mass matrices for which the non-algebraic part is singular")
   end
 
   if typeof(prob.u0) <: Number

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -2,13 +2,8 @@ function DiffEqBase.__solve(prob::DiffEqBase.AbstractSteadyStateProblem,
                             alg::SteadyStateDiffEqAlgorithm,args...;
                             abstol=1e-8,kwargs...)
 
-  # test if the solver is applicable
-  M = prob.f.mass_matrix
-  mask = [!iszero(M[i,:]) for i in 1:size(M,1)] # Create a mask to filter out the algebraic parts
-  M_rest = M[mask,mask] # Non-algebraic part
-  
-  if rank(M_rest) < minimum(size(M_rest)) 
-    error("This solver is not able to use mass matrices for which the non-algebraic part is singular")
+  if rank(prob.f.mass_matrix) < minimum(size(prob.f.mass_matrix)) 
+    error("This solver is not able to use singular mass matrices")
   end
 
   if typeof(prob.u0) <: Number

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -7,7 +7,7 @@ function DiffEqBase.__solve(prob::DiffEqBase.AbstractSteadyStateProblem,
   mask = [!iszero(M[i,:]) for i in 1:size(M,1)] # Create a mask to filter out the algebraic parts
   M_rest = M[mask,mask] # Non-algebraic part
   
-  if rank(M_rest) < minimum(size(A)) 
+  if rank(M_rest) < minimum(size(M_rest)) 
     error("This solver is not able to use mass matrices, wich non-algebraic part is singular")
   end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -2,8 +2,13 @@ function DiffEqBase.__solve(prob::DiffEqBase.AbstractSteadyStateProblem,
                             alg::SteadyStateDiffEqAlgorithm,args...;
                             abstol=1e-8,kwargs...)
 
-  if det(prob.f.mass_matrix) == 0
-    error("This solver is not able to use singular mass matrices.")
+  # test if the solver is applicable
+  M = prob.f.mass_matrix
+  mask = [!iszero(M[i,:]) for i in 1:size(M,1)] # Create a mask to filter out the algebraic parts
+  M_rest = M[mask,mask] # Non-algebraic part
+  
+  if rank(M_rest) < minimum(size(A)) 
+    error("This solver is not able to use mass matrices, wich non-algebraic part is singular")
   end
 
   if typeof(prob.u0) <: Number

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -2,7 +2,7 @@ function DiffEqBase.__solve(prob::DiffEqBase.AbstractSteadyStateProblem,
                             alg::SteadyStateDiffEqAlgorithm,args...;
                             abstol=1e-8,kwargs...)
 
-  if prob.f.mass_matrix !=I && rank(prob.f.mass_matrix) < minimum(size(prob.f.mass_matrix)) 
+  if prob.f.mass_matrix !== I && rank(prob.f.mass_matrix) < minimum(size(prob.f.mass_matrix)) 
     error("This solver is not able to use singular mass matrices")
   end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -2,7 +2,7 @@ function DiffEqBase.__solve(prob::DiffEqBase.AbstractSteadyStateProblem,
                             alg::SteadyStateDiffEqAlgorithm,args...;
                             abstol=1e-8,kwargs...)
 
-  if rank(prob.f.mass_matrix) < minimum(size(prob.f.mass_matrix)) 
+  if prob.f.mass_matrix !=I && rank(prob.f.mass_matrix) < minimum(size(prob.f.mass_matrix)) 
     error("This solver is not able to use singular mass matrices")
   end
 


### PR DESCRIPTION
If the mass matrix is non-singular the the only solution to M*dn/dt = 0 is the trivial one. In this case solving  f(u) = 0 leads to the correct steady state solution u.