### PR TITLE
Fix tspan type for complex utype

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -54,7 +54,7 @@ function DiffEqBase.__solve(prob::DiffEqBase.AbstractSteadyStateProblem,
                             alg::DynamicSS,args...;save_everystep=false,
                             save_start=false,kwargs...)
 
-  tspan = alg.tspan isa Tuple ? alg.tspan : convert.(eltype(prob.u0),(zero(alg.tspan), alg.tspan))
+  tspan = alg.tspan isa Tuple ? alg.tspan : convert.(real(eltype(prob.u0)),(zero(alg.tspan), alg.tspan))
   if typeof(prob) <: SteadyStateProblem
     f = prob.f
   elseif typeof(prob) <: NonlinearProblem

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,3 +78,15 @@ sol = solve(prob,DynamicSS(Tsit5(),tspan=1f-3))
 prob = SteadyStateProblem(ODEProblem(fiip,u0,tspan))
 sol2 = solve(prob,DynamicSS(Tsit5(),abstol=1e-4))
 @test typeof(u0) == typeof(sol2.u)
+
+# Complex u
+u0 = [1.0im]
+
+function fcomplex(du,u,p,t)
+    du[1] = (0.1im - 1)*u[1]
+end
+
+prob = SteadyStateProblem(ODEProblem(fcomplex,u0,(0.0,1.0)))
+sol = solve(prob,DynamicSS(Tsit5()))
+@test sol.retcode == :Success
+@test abs(sol.u[end]) < 1e-8


### PR DESCRIPTION
With #31 `tspan` gets converted to a complex type when using a complex `u`. This causes `solve` to fail with e.g. `MethodError: no method matching isless(::ComplexF64, ::ComplexF64)`.
This PR just makes the type to `real` fixing that. Also, I added a test for complex `u`.