### PR TITLE
fix: call `solve` instead of `__solve`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SteadyStateDiffEq"
 uuid = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,7 +1,7 @@
 function SciMLBase.__solve(prob::SciMLBase.AbstractSteadyStateProblem, alg::SSRootfind,
         args...; kwargs...)
     nlprob = NonlinearProblem(prob)
-    nlsol = SciMLBase.__solve(nlprob, alg.alg, args...; kwargs...)
+    nlsol = solve(nlprob, alg.alg, args...; kwargs...)
     return SciMLBase.build_solution(prob, SSRootfind(nlsol.alg), nlsol.u, nlsol.resid;
         nlsol.retcode, nlsol.stats, nlsol.left, nlsol.right, original = nlsol)
 end
@@ -53,7 +53,7 @@ function SciMLBase.__solve(prob::SciMLBase.AbstractSteadyStateProblem, alg::Dyna
 
     # Construct and solve the ODEProblem
     odeprob = ODEProblem{isinplace(prob)}(f, prob.u0, tspan, prob.p)
-    odesol = SciMLBase.__solve(odeprob, alg.alg, args...; abstol, reltol, kwargs...,
+    odesol = solve(odeprob, alg.alg, args...; abstol, reltol, kwargs...,
         odesolve_kwargs..., callback, save_end = true)
 
     resid, u, retcode = __get_result_from_sol(termination_condition, tc_cache, odesol)


### PR DESCRIPTION
calling `__solve` causes issues with the new change in SimpleNonlinearSolve which requires dispatches on immutable problems. See https://buildkite.com/julialang/deepequilibriumnetworks/builds/178#0191af24-a562-4984-a16c-688bf1325f79/462-1472 for the problem where the algorithm was ignored and the default nonlinear solve algorithm was called.