### PR TITLE
Documentation improvements: Update badges, fix URLs, and add usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,47 @@
 # SteadyStateDiffEq.jl
 
-[![Join the chat at https://gitter.im/JuliaDiffEq/Lobby](https://badges.gitter.im/JuliaDiffEq/Lobby.svg)](https://gitter.im/JuliaDiffEq/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
 [![Build Status](https://github.com/SciML/SteadyStateDiffEq.jl/workflows/Tests/badge.svg)](https://github.com/SciML/SteadyStateDiffEq.jl/actions?query=workflow%3ATests)
-[![Coverage Status](https://coveralls.io/repos/JuliaDiffEq/SteadyStateDiffEq.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaDiffEq/SteadyStateDiffEq.jl?branch=master)
-[![codecov.io](http://codecov.io/github/JuliaDiffEq/SteadyStateDiffEq.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaDiffEq/SteadyStateDiffEq.jl?branch=master)
+[![Coverage Status](https://coveralls.io/repos/SciML/SteadyStateDiffEq.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/SciML/SteadyStateDiffEq.jl?branch=master)
+[![codecov.io](http://codecov.io/github/SciML/SteadyStateDiffEq.jl/coverage.svg?branch=master)](http://codecov.io/github/SciML/SteadyStateDiffEq.jl?branch=master)
 
 SteadyStateDiffEq.jl is a component package in the DifferentialEquations ecosystem.
 It holds the steady state solvers for differential equations.
 While completely independent and usable on its own, users interested in using this
-functionality should check out [DifferentialEquations.jl](https://github.com/JuliaDiffEq/DifferentialEquations.jl).
+functionality should check out [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl).
+
+## Usage
+
+SteadyStateDiffEq.jl provides two main algorithms for finding steady states:
+
+### SSRootfind - Nonlinear Solver Approach
+
+Use a nonlinear solver to directly find the steady state:
+
+```julia
+using SteadyStateDiffEq, NonlinearSolve
+
+function f!(du, u, p, t)
+    du[1] = 2 - 2u[1]
+    du[2] = u[1] - 4u[2]
+end
+
+u0 = zeros(2)
+prob = SteadyStateProblem(f!, u0)
+sol = solve(prob, SSRootfind())
+```
+
+### DynamicSS - Time Evolution Approach
+
+Evolve the system forward in time until derivatives approach zero:
+
+```julia
+using SteadyStateDiffEq, OrdinaryDiffEq
+
+sol = solve(prob, DynamicSS(Tsit5()))
+```
+
+For more details, see the [SciML documentation](https://docs.sciml.ai/DiffEqDocs/stable/).
 
 ## Breaking Changes in v2
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -43,7 +43,7 @@ sol = solve(prob, DynamicSS(CVODE_BDF()); dt = 1.0)
 
 !!! note
 
-    If you use `CVODE_BDF` you may need to give a starting `dt` via `dt = ....`.*
+    If you use `CVODE_BDF` you may need to give a starting `dt` via `dt = ....`.
 """
 @concrete struct DynamicSS <: SteadyStateDiffEqAlgorithm
     alg


### PR DESCRIPTION
## Summary

This PR improves the documentation quality with several focused improvements:

- **Update README badges**: Replace outdated Gitter badge with current Zulip chat badge for SciML community
- **Fix repository URLs**: Update all `JuliaDiffEq` organization references to `SciML` 
- **Add usage examples**: Include clear quick-start examples demonstrating both `SSRootfind` and `DynamicSS` algorithms
- **Fix docstring typo**: Remove extra asterisk in `DynamicSS` docstring note about `CVODE_BDF`

## Testing

- All existing tests pass (2676 tests)
- Added examples are based on existing test code and verified to work correctly

## Changes

### README.md
- Updated chat badge from Gitter to Zulip
- Fixed coverage badge URLs (JuliaDiffEq → SciML)
- Fixed DifferentialEquations.jl link
- Added Usage section with practical examples for both algorithms

### src/algorithms.jl  
- Fixed typo: removed trailing `*` from CVODE_BDF note

These changes make it easier for new users to get started with the package and ensure all community links are current.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)