### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-annotate_untyped_fields_with_any = false

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/src/SteadyStateDiffEq.jl
+++ b/src/SteadyStateDiffEq.jl
@@ -7,13 +7,13 @@ using ConcreteStructs: @concrete
 using NonlinearSolveBase
 import DiffEqBase
 using NonlinearSolveBase: AbstractNonlinearTerminationMode,
-                          AbstractSafeNonlinearTerminationMode,
-                          AbstractSafeBestNonlinearTerminationMode,
-                          NormTerminationMode
+    AbstractSafeNonlinearTerminationMode,
+    AbstractSafeBestNonlinearTerminationMode,
+    NormTerminationMode
 using DiffEqCallbacks: TerminateSteadyState
 using LinearAlgebra: norm
 using SciMLBase: SciMLBase, CallbackSet, NonlinearProblem, ODEProblem,
-                 ReturnCode, SteadyStateProblem, get_du, init, isinplace
+    ReturnCode, SteadyStateProblem, get_du, init, isinplace
 
 const infnorm = Base.Fix2(norm, Inf)
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -60,8 +60,10 @@ end
 SciMLBase.isadaptive(::SSRootfind) = false
 
 for aType in (:SSRootfind, :DynamicSS),
-    op in (:isadaptive, :isautodifferentiable, :allows_arbitrary_number_types,
-        :allowscomplex)
+        op in (
+            :isadaptive, :isautodifferentiable, :allows_arbitrary_number_types,
+            :allowscomplex,
+        )
 
     op == :isadaptive && aType == :SSRootfind && continue
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,22 +1,29 @@
-function SciMLBase.__solve(prob::SciMLBase.AbstractSteadyStateProblem, alg::SSRootfind,
-        args...; kwargs...)
+function SciMLBase.__solve(
+        prob::SciMLBase.AbstractSteadyStateProblem, alg::SSRootfind,
+        args...; kwargs...
+    )
     nlprob = NonlinearProblem(prob)
     nlsol = solve(nlprob, alg.alg, args...; kwargs...)
-    return SciMLBase.build_solution(prob, SSRootfind(nlsol.alg), nlsol.u, nlsol.resid;
-        nlsol.retcode, nlsol.stats, nlsol.left, nlsol.right, original = nlsol)
+    return SciMLBase.build_solution(
+        prob, SSRootfind(nlsol.alg), nlsol.u, nlsol.resid;
+        nlsol.retcode, nlsol.stats, nlsol.left, nlsol.right, original = nlsol
+    )
 end
 
 __get_tspan(u0, alg::DynamicSS) = __get_tspan(u0, alg.tspan)
 __get_tspan(u0, tspan::Tuple) = tspan
 function __get_tspan(u0, tspan::Number)
     return convert.(
-        DiffEqBase.value(real(eltype(u0))), (DiffEqBase.value(zero(tspan)), tspan))
+        DiffEqBase.value(real(eltype(u0))), (DiffEqBase.value(zero(tspan)), tspan)
+    )
 end
 
-function SciMLBase.__solve(prob::SciMLBase.AbstractSteadyStateProblem, alg::DynamicSS,
-        args...; abstol = 1e-8, reltol = 1e-6, odesolve_kwargs = (;),
+function SciMLBase.__solve(
+        prob::SciMLBase.AbstractSteadyStateProblem, alg::DynamicSS,
+        args...; abstol = 1.0e-8, reltol = 1.0e-6, odesolve_kwargs = (;),
         save_idxs = nothing, termination_condition = NonlinearSolveBase.NormTerminationMode(infnorm),
-        alias = SciMLBase.NonlinearAliasSpecifier(), kwargs...)
+        alias = SciMLBase.NonlinearAliasSpecifier(), kwargs...
+    )
     tspan = __get_tspan(prob.u0, alg)
 
     f = if prob isa SteadyStateProblem
@@ -44,8 +51,10 @@ function SciMLBase.__solve(prob::SciMLBase.AbstractSteadyStateProblem, alg::Dyna
         return tc_cache(get_du(integrator), integrator.u, integrator.uprev, t)
     end
 
-    callback = TerminateSteadyState(abstol, reltol, terminate_function;
-        wrap_test = Val(false))
+    callback = TerminateSteadyState(
+        abstol, reltol, terminate_function;
+        wrap_test = Val(false)
+    )
 
     haskey(kwargs, :callback) && (callback = CallbackSet(callback, kwargs[:callback]))
     haskey(odesolve_kwargs, :callback) &&
@@ -53,10 +62,14 @@ function SciMLBase.__solve(prob::SciMLBase.AbstractSteadyStateProblem, alg::Dyna
     kwargs = pairs(merge((; kwargs...), haskey(kwargs, :verbose) ? (verbose = true,) : (;)))
     # Construct and solve the ODEProblem
     odeprob = ODEProblem{isinplace(prob), true}(f, prob.u0, tspan, prob.p)
-    odesol = solve(odeprob, alg.alg, args...; abstol, reltol, kwargs...,
+    odesol = solve(
+        odeprob, alg.alg, args...; abstol, reltol, kwargs...,
         odesolve_kwargs..., callback, save_end = true,
-        alias = SciMLBase.ODEAliasSpecifier(; alias_p = alias.alias_p,
-            alias_f = alias.alias_f, alias_u0 = alias.alias_u0))
+        alias = SciMLBase.ODEAliasSpecifier(;
+            alias_p = alias.alias_p,
+            alias_f = alias.alias_f, alias_u0 = alias.alias_u0
+        )
+    )
 
     resid, u, retcode = __get_result_from_sol(termination_condition, tc_cache, odesol)
 
@@ -65,16 +78,22 @@ function SciMLBase.__solve(prob::SciMLBase.AbstractSteadyStateProblem, alg::Dyna
         resid = resid[save_idxs]
     end
 
-    return SciMLBase.build_solution(prob, DynamicSS(odesol.alg, alg.tspan), u, resid;
-        retcode, original = odesol)
+    return SciMLBase.build_solution(
+        prob, DynamicSS(odesol.alg, alg.tspan), u, resid;
+        retcode, original = odesol
+    )
 end
 
 function __get_result_from_sol(::AbstractNonlinearTerminationMode, tc_cache, odesol)
     u, t = last(odesol.u), last(odesol.t)
     du = odesol(t, Val{1})
-    return (du, u,
-        ifelse(odesol.retcode == ReturnCode.Terminated, ReturnCode.Success,
-            ReturnCode.Failure))
+    return (
+        du, u,
+        ifelse(
+            odesol.retcode == ReturnCode.Terminated, ReturnCode.Success,
+            ReturnCode.Failure
+        ),
+    )
 end
 
 function __get_result_from_sol(::AbstractSafeNonlinearTerminationMode, tc_cache, odesol)

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -31,7 +31,7 @@ eqs = [
     D(y5) ~ (-1.745 * y5 + k5 * y6 + k5 * y7),
     D(y6) ~ (-k2 * y6 * y8 + k4 * y4 + k1 * y5 - k5 * y6 + k4 * y7),
     D(y7) ~ (k2 * y6 * y8 - k6 * y7),
-    D(y8) ~ (-k2 * y6 * y8 + k6 * y7)
+    D(y8) ~ (-k2 * y6 * y8 + k6 * y7),
 ]
 
 @mtkcompile model = System(eqs, t)
@@ -40,29 +40,47 @@ struct Tag end
 T = typeof(ForwardDiff.Tag(Tag(), Float64))
 
 u0 = [
-    Dual{T, Float64, 7}(1.8983788068509213,
-        ForwardDiff.Partials((0.6970981087506788, 0.0, 0.0, 0.0, 0.0, 0.0,
-            0.0))),
+    Dual{T, Float64, 7}(
+        1.8983788068509213,
+        ForwardDiff.Partials(
+            (
+                0.6970981087506788, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0,
+            )
+        )
+    ),
     Dual{T, Float64, 7}(0.0, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
     Dual{T, Float64, 7}(0.0, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
     Dual{T, Float64, 7}(0.0, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
     Dual{T, Float64, 7}(0.0, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
     Dual{T, Float64, 7}(0.0, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
     Dual{T, Float64, 7}(0.0, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
-    Dual{T, Float64, 7}(0.0057, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)))
+    Dual{T, Float64, 7}(0.0057, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
 ]
 
 p = [
-    Dual{T, Float64, 7}(1.5174072564237708,
-        ForwardDiff.Partials((0.0, 0.38355212192378396, 0.0, 0.0, 0.0, 0.0,
-            0.0))),
+    Dual{T, Float64, 7}(
+        1.5174072564237708,
+        ForwardDiff.Partials(
+            (
+                0.0, 0.38355212192378396, 0.0, 0.0, 0.0, 0.0,
+                0.0,
+            )
+        )
+    ),
     Dual{T, Float64, 7}(0.43, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
     Dual{T, Float64, 7}(8.32, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
-    Dual{T, Float64, 7}(268.1197063467946,
-        ForwardDiff.Partials((0.0, 0.0, 44.91823438292696, 0.0, 0.0, 0.0,
-            0.0))),
+    Dual{T, Float64, 7}(
+        268.1197063467946,
+        ForwardDiff.Partials(
+            (
+                0.0, 0.0, 44.91823438292696, 0.0, 0.0, 0.0,
+                0.0,
+            )
+        )
+    ),
     Dual{T, Float64, 7}(0.69, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
-    Dual{T, Float64, 7}(20.0, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)))
+    Dual{T, Float64, 7}(20.0, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
 ]
 
 prob = SteadyStateProblem(model, u0, p)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,38 +1,40 @@
 using SteadyStateDiffEq, NonlinearSolve, Sundials, OrdinaryDiffEq, DiffEqCallbacks, Test
 using NonlinearSolve.NonlinearSolveBase
 using NonlinearSolve.NonlinearSolveBase: NormTerminationMode, RelTerminationMode,
-                                         RelNormTerminationMode,
-                                         AbsTerminationMode, AbsNormTerminationMode
+    RelNormTerminationMode,
+    AbsTerminationMode, AbsNormTerminationMode
 
 function f(du, u, p, t)
     du[1] = 2 - 2u[1]
-    du[2] = u[1] - 4u[2]
+    return du[2] = u[1] - 4u[2]
 end
 
 u0 = zeros(2)
 prob = SteadyStateProblem(f, u0)
 
-@testset "NonlinearSolve: $(nameof(typeof(alg)))" for alg in (nothing,
-    NewtonRaphson(; autodiff = AutoFiniteDiff()), KINSOL())
+@testset "NonlinearSolve: $(nameof(typeof(alg)))" for alg in (
+        nothing,
+        NewtonRaphson(; autodiff = AutoFiniteDiff()), KINSOL(),
+    )
     sol = solve(prob, SSRootfind(alg))
     @test SciMLBase.successful_retcode(sol.retcode)
 
     du = zeros(2)
     f(du, sol.u, nothing, 0)
-    @test maximum(du) < 1e-11
+    @test maximum(du) < 1.0e-11
 end
 
 @testset "OrdinaryDiffEq" begin
     du = zeros(2)
     p = nothing
 
-    sol = solve(prob, DynamicSS(Tsit5()); abstol = 1e-9, reltol = 1e-9)
+    sol = solve(prob, DynamicSS(Tsit5()); abstol = 1.0e-9, reltol = 1.0e-9)
     @test SciMLBase.successful_retcode(sol.retcode)
 
     f(du, sol.u, p, 0)
-    @test du≈[0, 0] atol=1e-7
+    @test du ≈ [0, 0] atol = 1.0e-7
 
-    sol = solve(prob, DynamicSS(Tsit5(), tspan = 1e-3))
+    sol = solve(prob, DynamicSS(Tsit5(), tspan = 1.0e-3))
     @test sol.retcode != ReturnCode.Success
 
     sol = solve(prob, DynamicSS(CVODE_BDF()), dt = 1.0)
@@ -45,10 +47,10 @@ end
 
     # scalar save_idxs
     scalar_sol = solve(prob, DynamicSS(CVODE_BDF()), dt = 1.0, save_idxs = 1)
-    @test scalar_sol[1]≈sol[1] atol=1e-6
+    @test scalar_sol[1] ≈ sol[1] atol = 1.0e-6
 
     f(du, sol.u, p, 0)
-    @test du≈[0, 0] atol=1e-6
+    @test du ≈ [0, 0] atol = 1.0e-6
 end
 
 # Float32
@@ -58,13 +60,13 @@ function foop(u, p, t)
     @test eltype(u) == eltype(u0)
     dx = 2 - 2u[1]
     dy = u[1] - 4u[2]
-    [dx, dy]
+    return [dx, dy]
 end
 
 function fiip(du, u, p, t)
     @test eltype(u) == eltype(u0)
     du[1] = 2 - 2u[1]
-    du[2] = u[1] - 4u[2]
+    return du[2] = u[1] - 4u[2]
 end
 
 tspan = (0.0f0, 1.0f0)
@@ -74,19 +76,19 @@ prob = SteadyStateProblem(fiip, u0)
 sol = solve(proboop, DynamicSS(Tsit5(), tspan = 1.0f-3))
 @test typeof(u0) == typeof(sol.u)
 proboop = SteadyStateProblem(ODEProblem(foop, u0, tspan))
-sol2 = solve(proboop, DynamicSS(Tsit5()); abstol = 1e-4)
+sol2 = solve(proboop, DynamicSS(Tsit5()); abstol = 1.0e-4)
 @test typeof(u0) == typeof(sol2.u)
 
 sol = solve(prob, DynamicSS(Tsit5(), tspan = 1.0f-3))
 @test typeof(u0) == typeof(sol.u)
 prob = SteadyStateProblem(ODEProblem(fiip, u0, tspan))
-sol2 = solve(prob, DynamicSS(Tsit5()); abstol = 1e-4)
+sol2 = solve(prob, DynamicSS(Tsit5()); abstol = 1.0e-4)
 @test typeof(u0) == typeof(sol2.u)
 
 for termination_condition in [
-    NormTerminationMode(SteadyStateDiffEq.infnorm), RelTerminationMode(), RelNormTerminationMode(SteadyStateDiffEq.infnorm),
-    AbsTerminationMode(), AbsNormTerminationMode(SteadyStateDiffEq.infnorm)
-]
+        NormTerminationMode(SteadyStateDiffEq.infnorm), RelTerminationMode(), RelNormTerminationMode(SteadyStateDiffEq.infnorm),
+        AbsTerminationMode(), AbsNormTerminationMode(SteadyStateDiffEq.infnorm),
+    ]
     sol_tc = solve(prob, DynamicSS(Tsit5()); termination_condition)
     @show sol_tc.retcode, termination_condition
     @test SciMLBase.successful_retcode(sol_tc.retcode)
@@ -97,21 +99,25 @@ end
 u0 = [1.0im]
 
 function fcomplex(du, u, p, t)
-    du[1] = (0.1im - 1) * u[1]
+    return du[1] = (0.1im - 1) * u[1]
 end
 
 prob = SteadyStateProblem(ODEProblem(fcomplex, u0, (0.0, 1.0)))
 sol = solve(prob, DynamicSS(Tsit5()))
 @test SciMLBase.successful_retcode(sol.retcode)
-@test abs(sol.u[end]) < 1e-8
+@test abs(sol.u[end]) < 1.0e-8
 
 # Callbacks
 u0 = zeros(2)
 prob = SteadyStateProblem(f, u0)
 saved_values = SavedValues(Float64, Vector{Float64})
-cb = SavingCallback((u, t, integrator) -> copy(u), saved_values, save_everystep = true,
-    save_start = true)
-sol = solve(prob, DynamicSS(Tsit5()); callback = cb, save_everystep = true,
-    save_start = true)
+cb = SavingCallback(
+    (u, t, integrator) -> copy(u), saved_values, save_everystep = true,
+    save_start = true
+)
+sol = solve(
+    prob, DynamicSS(Tsit5()); callback = cb, save_everystep = true,
+    save_start = true
+)
 @test SciMLBase.successful_retcode(sol.retcode)
 @test isapprox(saved_values.saveval[end], sol.u)


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)