### PR TITLE
Fix deprecation warnings

### DIFF
--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -1,8 +1,8 @@
 using ModelingToolkit, OrdinaryDiffEq, ForwardDiff, Test, SteadyStateDiffEq
 using ForwardDiff: Dual
 
+@independent_variables t
 @variables begin
-    t
     y1(t) = 1.0
     y2(t) = 0.0
     y3(t) = 0.0
@@ -83,6 +83,8 @@ p = [
     Dual{T, Float64, 7}(20.0, ForwardDiff.Partials((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))),
 ]
 
-prob = SteadyStateProblem(model, u0, p)
-alg = DynamicSS(QNDF())
+prob = SteadyStateProblem(
+    model, merge(Dict(unknowns(model) .=> u0), Dict(parameters(model) .=> p))
+)
+alg = DynamicSS(Rodas5P())
 sol = solve(prob, alg)


### PR DESCRIPTION
## Summary

- Use `@independent_variables t` instead of defining `t` inside `@variables` block (fixes ModelingToolkitBase deprecation warning)
- Use new Dict-based `SteadyStateProblem` construction API instead of deprecated positional `(sys, u0, p)` form (fixes ModelingToolkitBase deprecation warning)
- Switch from `QNDF()` to `Rodas5P()` in autodiff test to work around upstream `OrdinaryDiffEqBDF` `MethodError` (missing `default_post_newton_controller!` for `QNDFCache` with `ForwardDiff.Dual` element types)

## Upstream issues

- **OrdinaryDiffEqBDF**: `default_post_newton_controller!` is not defined for `QNDFCache` when element types are `ForwardDiff.Dual`. The method only exists for `DefaultCache` and `CompositeCache` in `OrdinaryDiffEqCore/src/integrators/controllers.jl`. This causes a `MethodError` when using `QNDF()` with ForwardDiff dual numbers through ModelingToolkit. Switched to `Rodas5P()` as a workaround.

## Test plan

- [x] `JULIA_DEPWARN=error julia --project -e 'using Pkg; Pkg.test()'` passes (Core: 2676/2676, Autodiff: completes without error)
- [x] No deprecation warnings emitted during test run
- [x] Runic formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)