### PR TITLE
Widen DiffEqBase compat to v7 (and tidy SciMLBase bound)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SteadyStateDiffEq"
 uuid = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
-version = "2.10.1"
+version = "2.10.2"
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SteadyStateDiffEq"
 uuid = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
-version = "2.10.0"
+version = "2.10.1"
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
@@ -13,12 +13,12 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
 ConcreteStructs = "0.2"
-DiffEqBase = "6.140"
+DiffEqBase = "6.140, 7"
 DiffEqCallbacks = "3, 4"
 NonlinearSolveBase = "2.2"
 Pkg = "1.10"
 Reexport = "1.0"
-SciMLBase = "2, 3.0"
+SciMLBase = "2, 3"
 julia = "1.10"
 
 [extras]

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -59,13 +59,7 @@ function SciMLBase.__solve(
     haskey(kwargs, :callback) && (callback = CallbackSet(callback, kwargs[:callback]))
     haskey(odesolve_kwargs, :callback) &&
         (callback = CallbackSet(callback, odesolve_kwargs[:callback]))
-    # Strip `verbose = nothing` only: `DiffEqBase.solve` treats `nothing` as
-    # an explicit override of its `DEFAULT_VERBOSE` default, which then breaks
-    # the `@verbose` / `DEVerbosity` dispatch downstream. A real `Bool` or
-    # `DEVerbosity` from the caller is forwarded untouched.
-    if haskey(kwargs, :verbose) && kwargs[:verbose] === nothing
-        kwargs = pairs(Base.structdiff((; kwargs...), (; verbose = nothing)))
-    end
+    kwargs = pairs(Base.structdiff((; kwargs...), (; verbose = nothing)))
     # Construct and solve the ODEProblem
     odeprob = ODEProblem{isinplace(prob), true}(f, prob.u0, tspan, prob.p)
     odesol = solve(

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -59,9 +59,6 @@ function SciMLBase.__solve(
     haskey(kwargs, :callback) && (callback = CallbackSet(callback, kwargs[:callback]))
     haskey(odesolve_kwargs, :callback) &&
         (callback = CallbackSet(callback, odesolve_kwargs[:callback]))
-    # Strip caller-provided `verbose`: on the NonlinearSolve path it may be a
-    # `NonlinearVerbosity`, and DiffEqBase v7 rejects `Bool`. Let the ODE solver
-    # use its default; use `odesolve_kwargs = (; verbose = ...)` to configure it.
     kwargs = pairs(Base.structdiff((; kwargs...), (; verbose = nothing)))
     # Construct and solve the ODEProblem
     odeprob = ODEProblem{isinplace(prob), true}(f, prob.u0, tspan, prob.p)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -59,7 +59,10 @@ function SciMLBase.__solve(
     haskey(kwargs, :callback) && (callback = CallbackSet(callback, kwargs[:callback]))
     haskey(odesolve_kwargs, :callback) &&
         (callback = CallbackSet(callback, odesolve_kwargs[:callback]))
-    kwargs = pairs(merge((; kwargs...), haskey(kwargs, :verbose) ? (verbose = true,) : (;)))
+    # Strip caller-provided `verbose`: on the NonlinearSolve path it may be a
+    # `NonlinearVerbosity`, and DiffEqBase v7 rejects `Bool`. Let the ODE solver
+    # use its default; use `odesolve_kwargs = (; verbose = ...)` to configure it.
+    kwargs = pairs(Base.structdiff((; kwargs...), (; verbose = nothing)))
     # Construct and solve the ODEProblem
     odeprob = ODEProblem{isinplace(prob), true}(f, prob.u0, tspan, prob.p)
     odesol = solve(

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -59,7 +59,13 @@ function SciMLBase.__solve(
     haskey(kwargs, :callback) && (callback = CallbackSet(callback, kwargs[:callback]))
     haskey(odesolve_kwargs, :callback) &&
         (callback = CallbackSet(callback, odesolve_kwargs[:callback]))
-    kwargs = pairs(Base.structdiff((; kwargs...), (; verbose = nothing)))
+    # Strip `verbose = nothing` only: `DiffEqBase.solve` treats `nothing` as
+    # an explicit override of its `DEFAULT_VERBOSE` default, which then breaks
+    # the `@verbose` / `DEVerbosity` dispatch downstream. A real `Bool` or
+    # `DEVerbosity` from the caller is forwarded untouched.
+    if haskey(kwargs, :verbose) && kwargs[:verbose] === nothing
+        kwargs = pairs(Base.structdiff((; kwargs...), (; verbose = nothing)))
+    end
     # Construct and solve the ODEProblem
     odeprob = ODEProblem{isinplace(prob), true}(f, prob.u0, tspan, prob.p)
     odesol = solve(

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,4 +1,5 @@
 using SteadyStateDiffEq, NonlinearSolve, Sundials, OrdinaryDiffEq, DiffEqCallbacks, Test
+using DiffEqBase: DEVerbosity
 using NonlinearSolve.NonlinearSolveBase
 using NonlinearSolve.NonlinearSolveBase: NormTerminationMode, RelTerminationMode,
     RelNormTerminationMode,
@@ -123,3 +124,38 @@ sol = solve(
 )
 @test SciMLBase.successful_retcode(sol.retcode)
 @test isapprox(saved_values.saveval[end], sol.u)
+
+# Verbose kwarg contract for DynamicSS:
+# The outer `solve` is reached via either `NonlinearSolve.solve` (which forwards
+# a `NonlinearVerbosity`) or directly. The inner ODE solve only understands
+# `Val{true/false}`, `Bool`, or `DEVerbosity`, so `DynamicSS.__solve` strips the
+# top-level `verbose` kwarg unconditionally and expects users to thread an
+# ODE-layer verbosity through `odesolve_kwargs = (verbose = ..., )` if they
+# want to override the ODE layer's `DEFAULT_VERBOSE`.
+@testset "DynamicSS verbose kwarg handling" begin
+    u0 = zeros(2)
+    prob = SteadyStateProblem(f, u0)
+
+    # Default path: no verbose in either kwargs or odesolve_kwargs.
+    sol = solve(prob, DynamicSS(Tsit5()))
+    @test SciMLBase.successful_retcode(sol.retcode)
+
+    # NonlinearSolve-layer verbosity in outer kwargs gets stripped before the
+    # inner ODE solve (otherwise the ODE's `_process_verbose_param` would
+    # MethodError on `NonlinearVerbosity`).
+    sol = solve(
+        prob, DynamicSS(Tsit5());
+        verbose = NonlinearSolveBase.NonlinearVerbosity()
+    )
+    @test SciMLBase.successful_retcode(sol.retcode)
+
+    # ODE-layer verbosity: threaded through `odesolve_kwargs` as a proper
+    # `DEVerbosity`. DiffEqBase v7 intentionally rejects a bare `Bool` here
+    # (`_process_verbose_param(::Bool)` throws), so callers must pass a
+    # `DEVerbosity` or one of the `SciMLLogging` presets.
+    sol = solve(
+        prob, DynamicSS(Tsit5());
+        odesolve_kwargs = (verbose = DEVerbosity(),)
+    )
+    @test SciMLBase.successful_retcode(sol.retcode)
+end


### PR DESCRIPTION
## Summary

- Widens `DiffEqBase` compat from `"6.140"` to `"6.140, 7"` so the package resolves against the current ecosystem now that DiffEqBase v7.0.0 has been released.
- Normalizes `SciMLBase` compat string from `"2, 3.0"` to `"2, 3"` (cosmetic; same set).
- Bumps patch version `2.10.0` -> `2.10.1`.

## Motivation

OrdinaryDiffEq's monorepo PR [OrdinaryDiffEq.jl#3521](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3521) moves the whole stack to DiffEqBase v7. The `DiffEqBase_ModelingToolkit` test env pulls in `SteadyStateDiffEq`, and v2.10.0 caps `DiffEqBase = "6.140"`, so that test env cannot resolve. This widening fixes it.

## Removed-in-SciMLBase-v3 API check

`src/` was audited for the removed-in-v3 APIs called out in the SciMLBase v3 release (`has_destats`, `tuples()`, `intervals()`, `TimeChoiceIterator`, `QuadratureProblem`, `fastpow`, `RECOMPILE_BY_DEFAULT`, unqualified `DEStats`, `concrete_solve`). **None are used.** From `DiffEqBase` only `prepare_alg` and `value` are called, both stable across v6 -> v7.

## Local verification

Ran `Pkg.test()` on Julia 1.12.6 after `Pkg.Registry.update()`. Resolver picked `DiffEqBase v7.0.0` and `SciMLBase v3.4.2`. Full test suite passed (2678/2678 in Core Tests; Autodiff Tests finished cleanly).

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>