### PR TITLE
Re-enable downgrade CI with genuine test-at-floor (allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   test:
-    if: false  # Disabled: waiting on OrdinaryDiffEq updates. See #115
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -13,12 +13,13 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
 ConcreteStructs = "0.2"
-DiffEqBase = "6.140, 7"
-DiffEqCallbacks = "3, 4"
+DiffEqBase = "7"
+DiffEqCallbacks = "4.5.0"
+NonlinearSolve = "4.12"
 NonlinearSolveBase = "2.2"
 OrdinaryDiffEq = "6, 7"
 Pkg = "1.10"
-Reexport = "1.0"
+Reexport = "1.2.2"
 SciMLBase = "2, 3"
 julia = "1.10"
 


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the Downgrade workflow with `allow_reresolve: false` (genuine test-at-floor: tests run at the minimal/downgraded versions). Raises declared-dep `[compat]` lower bounds: `DiffEqBase = "7";DiffEqCallbacks = "4.5.0";NonlinearSolve = "4.12";Reexport = "1.2.2";`DiffEqBase = "7";DiffEqCallbacks = "4.5.0";NonlinearSolve = "4.12";Reexport = "1.2.2";

Verified locally on Julia 1.10 in a clean depot + fresh registry: downgrade resolve + `Pkg.test(allow_reresolve=false)` pass at the floor with 0 re-resolve. CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)