### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/src/SteadyStateDiffEq.jl
+++ b/src/SteadyStateDiffEq.jl
@@ -4,16 +4,14 @@ using Reexport: @reexport
 @reexport using SciMLBase
 
 using ConcreteStructs: @concrete
-using NonlinearSolveBase
 import DiffEqBase
-using NonlinearSolveBase: AbstractNonlinearTerminationMode,
+using NonlinearSolveBase: NonlinearSolveBase, AbstractNonlinearTerminationMode,
     AbstractSafeNonlinearTerminationMode,
-    AbstractSafeBestNonlinearTerminationMode,
-    NormTerminationMode
+    AbstractSafeBestNonlinearTerminationMode
 using DiffEqCallbacks: TerminateSteadyState
 using LinearAlgebra: norm
 using SciMLBase: SciMLBase, CallbackSet, NonlinearProblem, ODEProblem,
-    ReturnCode, SteadyStateProblem, get_du, init, isinplace
+    ReturnCode, SteadyStateProblem, get_du, init, isinplace, solve
 
 const infnorm = Base.Fix2(norm, Inf)
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -14,7 +14,7 @@ __get_tspan(u0, alg::DynamicSS) = __get_tspan(u0, alg.tspan)
 __get_tspan(u0, tspan::Tuple) = tspan
 function __get_tspan(u0, tspan::Number)
     return convert.(
-        DiffEqBase.value(real(eltype(u0))), (DiffEqBase.value(zero(tspan)), tspan)
+        SciMLBase.value(real(eltype(u0))), (SciMLBase.value(zero(tspan)), tspan)
     )
 end
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SteadyStateDiffEq = { path = "../.." }
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SteadyStateDiffEq = { path = "../.." }
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1.6"
+SciMLTesting = "1.7"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,10 +1,37 @@
-using Aqua, JET, SteadyStateDiffEq, Test
+using SciMLTesting, SteadyStateDiffEq, Test
+using JET
 
-@testset "Aqua" begin
-    Aqua.test_all(SteadyStateDiffEq; deps_compat = false)
-    @test_broken false  # Aqua deps_compat: missing [compat] for stdlib LinearAlgebra — see https://github.com/SciML/SteadyStateDiffEq.jl/issues/134
-end
-
-@testset "JET" begin
-    JET.test_package(SteadyStateDiffEq; target_defined_modules = true)
-end
+run_qa(
+    SteadyStateDiffEq;
+    explicit_imports = true,
+    jet_kwargs = (; target_defined_modules = true),
+    # Aqua deps_compat: missing [compat] for stdlib LinearAlgebra
+    # https://github.com/SciML/SteadyStateDiffEq.jl/issues/134
+    aqua_broken = (:deps_compat,),
+    ei_kwargs = (
+        # `value` is owned by SciMLBase but re-exported and accessed via DiffEqBase.
+        all_qualified_accesses_via_owners = (; ignore = (:value,)),
+        # Non-public names of upstream SciML packages (SciMLBase, NonlinearSolveBase,
+        # DiffEqBase) and Base accessed by qualification; they go public as those
+        # libraries declare them.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :AbstractSteadyStateAlgorithm, :AbstractSteadyStateProblem,  # SciMLBase
+                :NonlinearAliasSpecifier, :__solve, :build_solution, :isadaptive,  # SciMLBase
+                :Default, :Failure, :Success, :Terminated,  # SciMLBase.ReturnCode
+                :Fix2, :structdiff,  # Base
+                :get_abstol, :get_reltol,  # NonlinearSolveBase
+                :prepare_alg,  # DiffEqBase
+                :value,  # SciMLBase (accessed via DiffEqBase)
+            ),
+        ),
+        # Non-public NonlinearSolveBase termination-mode abstract types imported explicitly.
+        all_explicit_imports_are_public = (;
+            ignore = (
+                :AbstractNonlinearTerminationMode,
+                :AbstractSafeBestNonlinearTerminationMode,
+                :AbstractSafeNonlinearTerminationMode,  # NonlinearSolveBase
+            ),
+        ),
+    ),
+)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -11,18 +11,16 @@ run_qa(
     ei_kwargs = (
         # `value` is owned by SciMLBase but re-exported and accessed via DiffEqBase.
         all_qualified_accesses_via_owners = (; ignore = (:value,)),
-        # Non-public names of upstream SciML packages (SciMLBase, NonlinearSolveBase,
-        # DiffEqBase) and Base accessed by qualification; they go public as those
-        # libraries declare them.
+        # Names still not declared public by their owning package (or Base) as of
+        # SciMLBase 3.24, NonlinearSolveBase 2.31, DiffEqBase 7.5; drop each as it
+        # is made public upstream.
         all_qualified_accesses_are_public = (;
             ignore = (
                 :AbstractSteadyStateAlgorithm, :AbstractSteadyStateProblem,  # SciMLBase
-                :NonlinearAliasSpecifier, :__solve, :build_solution, :isadaptive,  # SciMLBase
-                :Default, :Failure, :Success, :Terminated,  # SciMLBase.ReturnCode
-                :Fix2, :structdiff,  # Base
+                :NonlinearAliasSpecifier, :__solve, :isadaptive,  # SciMLBase
                 :get_abstol, :get_reltol,  # NonlinearSolveBase
-                :prepare_alg,  # DiffEqBase
-                :value,  # SciMLBase (accessed via DiffEqBase)
+                :prepare_alg, :value,  # DiffEqBase
+                :structdiff,  # Base
             ),
         ),
         # Non-public NonlinearSolveBase termination-mode abstract types imported explicitly.

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -9,15 +9,12 @@ run_qa(
     # https://github.com/SciML/SteadyStateDiffEq.jl/issues/134
     aqua_broken = (:deps_compat,),
     ei_kwargs = (
-        # `value` is owned by SciMLBase but re-exported and accessed via DiffEqBase.
-        all_qualified_accesses_via_owners = (; ignore = (:value,)),
-        # Names still not declared public by their owning package (or Base) as of
-        # SciMLBase 3.27, NonlinearSolveBase 2.31, DiffEqBase 7.6; drop each as it
-        # is made public upstream.
+        # Names still not declared public by their owning package (or Base); drop each
+        # as it is made public upstream.
         all_qualified_accesses_are_public = (;
             ignore = (
-                :AbstractSteadyStateProblem, :__solve,  # SciMLBase
-                :prepare_alg, :value,  # DiffEqBase
+                :AbstractSteadyStateProblem, :__solve, :value,  # SciMLBase
+                :prepare_alg,  # DiffEqBase
                 :structdiff,  # Base
             ),
         ),

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -12,12 +12,11 @@ run_qa(
         # `value` is owned by SciMLBase but re-exported and accessed via DiffEqBase.
         all_qualified_accesses_via_owners = (; ignore = (:value,)),
         # Names still not declared public by their owning package (or Base) as of
-        # SciMLBase 3.24, NonlinearSolveBase 2.31, DiffEqBase 7.5; drop each as it
+        # SciMLBase 3.27, NonlinearSolveBase 2.31, DiffEqBase 7.6; drop each as it
         # is made public upstream.
         all_qualified_accesses_are_public = (;
             ignore = (
-                :AbstractSteadyStateAlgorithm, :AbstractSteadyStateProblem,  # SciMLBase
-                :NonlinearAliasSpecifier, :__solve, :isadaptive,  # SciMLBase
+                :AbstractSteadyStateProblem, :__solve,  # SciMLBase
                 :get_abstol, :get_reltol,  # NonlinearSolveBase
                 :prepare_alg, :value,  # DiffEqBase
                 :structdiff,  # Base

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -17,17 +17,14 @@ run_qa(
         all_qualified_accesses_are_public = (;
             ignore = (
                 :AbstractSteadyStateProblem, :__solve,  # SciMLBase
-                :get_abstol, :get_reltol,  # NonlinearSolveBase
                 :prepare_alg, :value,  # DiffEqBase
                 :structdiff,  # Base
             ),
         ),
-        # Non-public NonlinearSolveBase termination-mode abstract types imported explicitly.
+        # Non-public NonlinearSolveBase termination-mode abstract type imported explicitly.
         all_explicit_imports_are_public = (;
             ignore = (
-                :AbstractNonlinearTerminationMode,
-                :AbstractSafeBestNonlinearTerminationMode,
-                :AbstractSafeNonlinearTerminationMode,  # NonlinearSolveBase
+                :AbstractSafeBestNonlinearTerminationMode,  # NonlinearSolveBase
             ),
         ),
     ),


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts `test/qa/qa.jl` from hand-rolled `Aqua.test_all` + `JET.test_package` to the SciMLTesting 1.6 `run_qa` form, with ExplicitImports enabled.

## What changed

- **`test/qa/qa.jl`** -> single `run_qa(SteadyStateDiffEq; explicit_imports = true, ...)` call.
- **`test/qa/Project.toml`** -> `SciMLTesting` compat bumped to `"1.6"`. Aqua/JET kept as direct deps (Aqua needed for the ambiguities child-process subcheck; JET runs). ExplicitImports stays transitive via SciMLTesting.
- **`src/SteadyStateDiffEq.jl`** -> import cleanups to resolve EI findings (below).

## Preserved tracked-broken finding

`aqua_broken = (:deps_compat,)` replaces the prior `deps_compat = false` + `@test_broken false`. Under v1.6 this both disables the `deps_compat` subcheck inside `Aqua.test_all` and emits a tracked `@test_broken` placeholder, so the missing-`LinearAlgebra`-stdlib-compat finding (#134) stays tracked and flips to an Unexpected Pass once fixed. JET remains a pass/fail check (`jet_kwargs = (; target_defined_modules = true)`).

## ExplicitImports findings (6 checks)

FIXED (source edits):
- `no_implicit_imports`: made `solve` (`using SciMLBase: ..., solve`) and the `NonlinearSolveBase` module name (`using NonlinearSolveBase: NonlinearSolveBase, ...`) explicit.
- `no_stale_explicit_imports`: removed unused `NormTerminationMode` from the explicit import list (only ever referenced module-qualified as `NonlinearSolveBase.NormTerminationMode`).
- `all_explicit_imports_via_owners`: passes.

IGNORED via `ei_kwargs` (other-package non-public names; will go public as base libs declare them; each ignore documented with its source package):
- `all_qualified_accesses_via_owners`: `value` (owned by SciMLBase, accessed via DiffEqBase re-export).
- `all_qualified_accesses_are_public`: SciMLBase (`AbstractSteadyStateAlgorithm`, `AbstractSteadyStateProblem`, `NonlinearAliasSpecifier`, `__solve`, `build_solution`, `isadaptive`, `value`), `SciMLBase.ReturnCode` (`Default`, `Failure`, `Success`, `Terminated`), Base (`Fix2`, `structdiff`), NonlinearSolveBase (`get_abstol`, `get_reltol`), DiffEqBase (`prepare_alg`).
- `all_explicit_imports_are_public`: NonlinearSolveBase termination-mode abstract types (`AbstractNonlinearTerminationMode`, `AbstractSafeNonlinearTerminationMode`, `AbstractSafeBestNonlinearTerminationMode`).

No `ei_broken` needed.

## Local verification (released SciMLTesting 1.6.0, Julia 1.10)

```
Test Summary:     | Pass  Broken  Total   Time
Quality Assurance |   14       1     15  40.9s
```

All 6 EI checks pass, Aqua (minus deps_compat) passes, JET passes; the single Broken is the tracked deps_compat placeholder (#134). 0 Fail / 0 Error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)