### PR TITLE
Add public API docs coverage

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,18 @@
+name: "Documentation"
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+
+jobs:
+  build-and-deploy-docs:
+    name: "Documentation"
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+.julia_depot/
+docs/build/

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
+
+[sources]
+SteadyStateDiffEq = { path = ".." }
+
+[compat]
+Documenter = "1"
+SteadyStateDiffEq = "2"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,23 @@
+using Documenter, SteadyStateDiffEq
+
+DocMeta.setdocmeta!(
+    SteadyStateDiffEq, :DocTestSetup, :(using SteadyStateDiffEq); recursive = true
+)
+
+makedocs(
+    sitename = "SteadyStateDiffEq.jl",
+    authors = "Chris Rackauckas",
+    clean = true,
+    doctest = false,
+    format = Documenter.HTML(
+        canonical = "https://docs.sciml.ai/SteadyStateDiffEq/stable/"
+    ),
+    pages = [
+        "Home" => "index.md",
+    ]
+)
+
+deploydocs(
+    repo = "github.com/SciML/SteadyStateDiffEq.jl";
+    push_preview = true
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,36 @@
+# SteadyStateDiffEq.jl
+
+SteadyStateDiffEq.jl provides algorithms for solving steady-state problems in the
+SciML ecosystem.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("SteadyStateDiffEq")
+```
+
+## Usage
+
+Use `SSRootfind` to solve the steady-state residual equation with a nonlinear solver:
+
+```julia
+using SteadyStateDiffEq, NonlinearSolve
+
+sol = solve(prob, SSRootfind(NewtonRaphson()))
+```
+
+Use `DynamicSS` to integrate the system until its derivative is close to zero:
+
+```julia
+using SteadyStateDiffEq, OrdinaryDiffEq
+
+sol = solve(prob, DynamicSS(Tsit5()))
+```
+
+## API
+
+```@docs
+SSRootfind
+DynamicSS
+```

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3,8 +3,21 @@ abstract type SteadyStateDiffEqAlgorithm <: SciMLBase.AbstractSteadyStateAlgorit
 """
     SSRootfind(alg = nothing)
 
-Use a Nonlinear Solver to find the steady state. Requires that a nonlinear solver is
-given as the first argument.
+Solve a steady-state problem by converting it to a `NonlinearProblem` and calling a
+nonlinear solver.
+
+## Arguments
+
+  - `alg`: the nonlinear solver algorithm passed to `solve`. When `alg === nothing`,
+    the default nonlinear solver is selected by the downstream solver package.
+
+## Example
+
+```julia
+using SteadyStateDiffEq, NonlinearSolve
+
+sol = solve(prob, SSRootfind(NewtonRaphson()))
+```
 
 !!! note
 
@@ -20,13 +33,24 @@ SSRootfind() = SSRootfind(nothing)
 """
     DynamicSS(alg = nothing; tspan = Inf)
 
-Requires that an ODE algorithm is given as the first argument.  The absolute and
-relative tolerances specify the termination conditions on the derivative's closeness to
-zero.  This internally uses the `TerminateSteadyState` callback from the Callback Library.
-The simulated time for which given ODE is solved can be limited by `tspan`.  If `tspan` is
-a number, it is equivalent to passing `(zero(tspan), tspan)`.
+Solve a steady-state problem by evolving the corresponding ODE until the derivative is
+close to zero.
 
-Example usage:
+`DynamicSS` internally adds a `TerminateSteadyState` callback. The `abstol` and
+`reltol` keywords passed to `solve` control the steady-state termination condition. Use
+`odesolve_kwargs` to pass separate keyword arguments to the ODE solve.
+
+## Arguments
+
+  - `alg`: the ODE solver algorithm passed to `solve`. When `alg === nothing`, the
+    default ODE solver is selected by the downstream solver package.
+
+## Keywords
+
+  - `tspan`: the time span used for the ODE solve. If `tspan` is a number, it is
+    equivalent to `(zero(tspan), tspan)`.
+
+## Example
 
 ```julia
 using SteadyStateDiffEq, OrdinaryDiffEq

--- a/test/qa/public_api_docs.jl
+++ b/test/qa/public_api_docs.jl
@@ -1,0 +1,149 @@
+using SteadyStateDiffEq, Test
+
+function _strip_comment(line)
+    io = IOBuffer()
+    in_string = false
+    quotechar = '\0'
+    escaped = false
+
+    for char in line
+        if escaped
+            print(io, char)
+            escaped = false
+        elseif char == '\\'
+            print(io, char)
+            escaped = true
+        elseif in_string
+            print(io, char)
+            char == quotechar && (in_string = false)
+        elseif char == '"' || char == '\''
+            print(io, char)
+            in_string = true
+            quotechar = char
+        elseif char == '#'
+            break
+        else
+            print(io, char)
+        end
+    end
+
+    return String(take!(io))
+end
+
+function _public_names_from_statement(statement)
+    normalized = replace(statement, r"^\s*(export|public|@public)\s+" => "")
+    normalized = replace(normalized, r"\b(export|public)\b" => "")
+    normalized = replace(normalized, "@public" => "")
+    normalized = replace(normalized, r"Expr\s*\(\s*:public\s*,?" => "")
+    normalized = replace(normalized, r"eval\s*\(" => "")
+    normalized = replace(normalized, r"Symbol\s*\(\s*\"(@?[A-Za-z_][A-Za-z0-9_!]*)\"\s*\)" => s"\1")
+    normalized = replace(normalized, ')' => " ")
+    normalized = replace(normalized, ':' => "")
+
+    public_names = Symbol[]
+    for token in split(normalized, [',', ' ', '\t', '\n'])
+        name = strip(token)
+        isempty(name) && continue
+        occursin(r"^@?[A-Za-z_][A-Za-z0-9_!]*$", name) || continue
+        name in ("return", "symbols", "symbols_expr") && continue
+        push!(public_names, Symbol(name))
+    end
+
+    return public_names
+end
+
+function _source_public_names()
+    src_root = normpath(joinpath(@__DIR__, "..", "..", "src"))
+    public_names = Symbol[]
+
+    for (root, _, files) in walkdir(src_root)
+        for file in files
+            endswith(file, ".jl") || continue
+            path = joinpath(root, file)
+            lines = readlines(path)
+            in_docstring = false
+            line_index = 1
+
+            while line_index <= length(lines)
+                line = lines[line_index]
+                if occursin("\"\"\"", line)
+                    in_docstring = !in_docstring
+                    count("\"\"\"", line) >= 2 && (in_docstring = !in_docstring)
+                end
+
+                raw = in_docstring ? "" : _strip_comment(line)
+                stripped = strip(raw)
+                if startswith(stripped, "export ") ||
+                        startswith(stripped, "public ") ||
+                        startswith(stripped, "@public ") ||
+                        occursin("Expr(:public", stripped) ||
+                        occursin("Expr(:(public)", stripped)
+                    statement = raw
+                    parens = count(==('('), statement) - count(==(')'), statement)
+                    while (endswith(rstrip(statement), ",") || parens > 0) &&
+                            line_index < length(lines)
+                        line_index += 1
+                        statement *= " " * _strip_comment(lines[line_index])
+                        parens = count(==('('), statement) - count(==(')'), statement)
+                    end
+                    append!(public_names, _public_names_from_statement(statement))
+                end
+
+                line_index += 1
+            end
+        end
+    end
+
+    return sort!(unique(public_names))
+end
+
+function _rendered_docs_entries()
+    docs_root = normpath(joinpath(@__DIR__, "..", "..", "docs", "src"))
+    entries = Set{Symbol}()
+
+    for (root, _, files) in walkdir(docs_root)
+        for file in files
+            endswith(file, ".md") || continue
+            in_docs_block = false
+            for line in eachline(joinpath(root, file))
+                stripped = strip(line)
+                if stripped == "```@docs"
+                    in_docs_block = true
+                    continue
+                elseif startswith(stripped, "```")
+                    in_docs_block = false
+                    continue
+                end
+
+                in_docs_block || continue
+                isempty(stripped) && continue
+                startswith(stripped, "#") && continue
+                identifier = replace(stripped, r"\(.*" => "")
+                identifier = split(identifier, ".")[end]
+                isempty(identifier) || push!(entries, Symbol(identifier))
+            end
+        end
+    end
+
+    return entries
+end
+
+function _has_docstring(mod::Module, name::Symbol)
+    return haskey(Docs.meta(mod), Docs.Binding(mod, name))
+end
+
+@testset "SteadyStateDiffEq-owned public API docs" begin
+    public_names = _source_public_names()
+    owned_exports = filter(sort!(collect(names(SteadyStateDiffEq; all = false)))) do name
+        name !== :SteadyStateDiffEq && parentmodule(getfield(SteadyStateDiffEq, name)) === SteadyStateDiffEq
+    end
+
+    @test public_names == owned_exports
+
+    undocumented = filter(name -> !_has_docstring(SteadyStateDiffEq, name), public_names)
+    @test isempty(undocumented)
+
+    rendered_entries = _rendered_docs_entries()
+    missing_rendered = filter(name -> name ∉ rendered_entries, public_names)
+    @test isempty(missing_rendered)
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, SteadyStateDiffEq, Test
 using JET
 
+include("public_api_docs.jl")
+
 run_qa(
     SteadyStateDiffEq;
     explicit_imports = true,


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Add a minimal Documenter site for SteadyStateDiffEq.jl and render the package-owned public API entries for `SSRootfind` and `DynamicSS`.
- Expand the algorithm docstrings into clearer SciML-style source-site documentation.
- Add QA coverage that scans source public declarations (`export`, `public`, `@public`, and `Expr(:public, ...)`) and checks source docstrings plus rendered `@docs` entries.
- Add the standard SciML documentation workflow so docs are built on PRs and `master`.

## Validation
- `julia --project=@runic -m Runic --check --diff src test docs/make.jl`
- `julia --project=test/qa test/qa/qa.jl`
- `julia --project=docs docs/make.jl`
- `typos .github/workflows/Documentation.yml .gitignore docs src/algorithms.jl test/qa/qa.jl test/qa/public_api_docs.jl`

Local docs deployment was skipped by Documenter because this was not running in a CI deployment environment.