### PR TITLE
Bump version to 2.11.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SteadyStateDiffEq"
 uuid = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
-version = "2.11.1"
+version = "2.11.2"
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"


### PR DESCRIPTION
Automated patch version bump (2.11.1 -> 2.11.2) to release unreleased commits on `master` via JuliaRegistrator.