### PR TITLE
Release prep: bump SteadyStateDiffEq to 2.11.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SteadyStateDiffEq"
 uuid = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
-version = "2.11.2"
+version = "2.11.3"
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/docs/test-scaffolding changes since 2.11.2.