### PR TITLE
Restore the local documentation source

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,6 +6,9 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 
+[sources]
+SteadyStateDiffEq = {path = ".."}
+
 [compat]
 Documenter = "1"
 NonlinearSolve = "4.12"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- restore the existing `docs/Project.toml` `[sources]` entry removed by #146
- keep documentation builds pinned to the SteadyStateDiffEq checkout instead of a registered release

## Local verification

- Julia 1.12.6 documentation build and doctests: passed
- asserted `pathof(SteadyStateDiffEq)` resolves to this checkout before building
- Runic 1.7.0: passed
- `git diff --check`: passed

The requested `Base.Fix2(norm, Inf)` correction was included in the merge commit for #146 and is already on `master`; this follow-up contains only the source restoration.