### PR TITLE
Set SteadyStateDiffEq version to 2.13.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SteadyStateDiffEq"
 uuid = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
-version = "2.12.0"
+version = "2.13.0"
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| SteadyStateDiffEq | 2.12.0 | 2.12.0 | 2.13.0 | minor |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total     Time / QA/qa.jl      |   21     21  1m40.6s / Testing SteadyStateDiffEq tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total     Time / Core/core.jl  | 2681   2681  1m24.4s / Test Summary: | Pass  Total     Time / Core/sicnm.jl |   33     33  2m20.9s / Testing SteadyStateDiffEq tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- SteadyStateDiffEq: `@JuliaRegistrator register`