### PR TITLE
Require Symbolics 7.39.2 (32-bit hasha_seed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,8 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 
-[compat]Symbolics = "7.39.2"
+[compat]
+Symbolics = "7.39.2"
 
 ConcreteStructs = "0.2"
 DiffEqBase = "7"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,8 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 
-[compat]
+[compat]Symbolics = "7.39.2"
+
 ConcreteStructs = "0.2"
 DiffEqBase = "7"
 DiffEqCallbacks = "4.5.0"
@@ -35,6 +36,7 @@ Test = "1"
 julia = "1.10"
 
 [extras]
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
@@ -44,4 +46,4 @@ Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OrdinaryDiffEq", "NonlinearSolve", "ModelingToolkit", "SciMLTesting", "Test", "SafeTestsets", "Sundials"]
+test = ["Symbolics", "OrdinaryDiffEq", "NonlinearSolve", "ModelingToolkit", "SciMLTesting", "Test", "SafeTestsets", "Sundials"]


### PR DESCRIPTION
## Summary
- Force `Symbolics = "7.39.2"` so x86 CI resolves SymbolicUtils ≥4.46.4.
- Adds Symbolics as a test extra when it was only transitive via ModelingToolkit.

## Test plan
- [ ] x86 Core green
- [ ] Matching non-x86 Core still green

Made with [Cursor](https://cursor.com)