### PR TITLE
Drop temporary Sundials URL sources (use 6.7.1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,6 +50,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [targets]
 test = ["Symbolics", "OrdinaryDiffEq", "NonlinearSolve", "ModelingToolkit", "SciMLTesting", "Test", "SafeTestsets", "Sundials"]
 
-[sources]
-Sundials = {url = "https://github.com/ChrisRackauckas-Claude/Sundials.jl.git", rev = "fix-32bit-nvector-length"}
 


### PR DESCRIPTION
## Summary
- Remove temporary Sundials URL `[sources]` pin now that **6.7.1** (NVector Int32 fix) is registering via [General#167662](https://github.com/JuliaRegistries/General/pull/167662).

## Test plan
- [ ] After Sundials 6.7.1 propagates, x86 Core green


Made with [Cursor](https://cursor.com)