### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "OrdinaryDiffEq,NonlinearSolve"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,46 @@
+using SteadyStateDiffEq, OrdinaryDiffEq, NonlinearSolve, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# Steady state of du = p[1] - p[2]*u - u^2
+function f_ss(du, u, p, t)
+    du[1] = p[1] - p[2] * u[1] - u[1]^2
+    return nothing
+end
+prob_scalar = SteadyStateProblem(ODEFunction(f_ss), [0.5], [1.0, 0.5])
+
+function f_vec(du, u, p, t)
+    du[1] = u[2]
+    du[2] = -p[1] * u[1] - p[2] * u[2]
+    return nothing
+end
+prob_vec = SteadyStateProblem(ODEFunction(f_vec), [1.0, 0.5], [2.0, 0.3])
+
+# =============================================================================
+# Steady-state solves
+# =============================================================================
+
+SUITE["solve"] = BenchmarkGroup()
+
+# Rootfind approach (Newton on f(u) = 0)
+SUITE["solve"]["ssrootfind_scalar"] = @benchmarkable solve(
+    $prob_scalar, SSRootfind()
+)
+SUITE["solve"]["ssrootfind_vec"] = @benchmarkable solve($prob_vec, SSRootfind())
+
+# Dynamic steady-state (integrate to convergence)
+SUITE["solve"]["dynamicss_scalar"] = @benchmarkable solve(
+    $prob_scalar, DynamicSS(Tsit5())
+)
+SUITE["solve"]["dynamicss_vec"] = @benchmarkable solve(
+    $prob_vec, DynamicSS(Tsit5())
+)
+
+# =============================================================================
+# Problem construction
+# =============================================================================
+
+SUITE["construct"] = BenchmarkGroup()
+SUITE["construct"]["steadystateproblem"] = @benchmarkable SteadyStateProblem(
+    $(ODEFunction(f_ss)), [0.5], [1.0, 0.5]
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~35s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~35s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md